### PR TITLE
Fix typo in driver-slack.md

### DIFF
--- a/driver-slack.md
+++ b/driver-slack.md
@@ -10,7 +10,7 @@
 <a id="installation-setup"></a>
 ## Installation & Setup
 
-First you need to pull in the Nexmo Driver.
+First you need to pull in the Slack Driver.
 
 ```sh
 composer require botman/driver-slack


### PR DESCRIPTION
Incorrect service name Nexmo rather than Slack.