### PR TITLE
Update installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -60,6 +60,9 @@ use BotMan\BotMan\BotManFactory;
 
 $config = [
     // Your driver-specific configuration
+    // "telegram" => [
+    //    "token" => "TOKEN"
+    // ]
 ];
 
 // create an instance


### PR DESCRIPTION
I had trouble with BotMan + Telegram for 1.5 hour because I misunderstood that we need to pass `key => array` for each driver and not directly Telegram `token` to config array. So I propose to include that in example. Maybe worth noting that config array can have many drivers settings.
BotMan silently fails in `reply` method if it can't find token in Telegram driver. I think it would be better to throw some `Exception` because it doesn't make sence to work without token. I needed to go to source code and found out that API URL is incorrectly formed because BotMan did not get my token and it said nothing about it which is incredibly wrong.