### PR TITLE
Update faq.md

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -7,6 +7,7 @@
 - [Does it work without Laravel?](#does-it-work-without-laravel)
 - [Which PHP version do I need?](#which-php-version-do-i-need)
 - [How does BotMan saves the state of a conversation?](#how-does-botman-saves-the-state-of-a-conversation)
+- [Why when I change the webhook URL to something other than /botman does it stop working?](#change-web-hook-url)
 
 <a id="what-can-i-use-botman-for"></a>
 ## What can I use BotMan for?
@@ -44,3 +45,10 @@ BotMan requires PHP >=7.0.
 BotMan provides a Conversation object that is used to string together several messages, including questions for the user, into a cohesive unit. In order to always know the current state of the conversation, the object gets saved through the cache.
 
 If not specified otherwise, BotMan will use array cache which is non-persistent. When using the Laravel facade it will automatically use the Laravel Cache component. Symfony and Codeigniter caches are also supported.
+
+<a id="change-web-hook-url"></a>
+## Why when I change the webhook URL to something other than /botman does it stop working?
+
+Laravel protects your application from cross-site request forgery (CSRF) attacks and as a result all requests are subject to a CSRF token verification. As the token is not passed along with the request from Facebook you need to exclude your webhook from CSRF checks. 
+
+You can exclude the routes by adding their URIs to the $except property of the VerifyCsrfToken middleware.


### PR DESCRIPTION
After changing the webhook URI from `/botman` it will stop the webhook from working. It took me some time to figure out that the URI needs excluding from CSRF checks.

It wasn't immediately clear what was required after changing the URI to anything other than `/botman` so I think this would benefit from being documented, as an FAQ entry, at least.