### PR TITLE
Update Symfony cache driver documentation.

### DIFF
--- a/cache-drivers.md
+++ b/cache-drivers.md
@@ -61,8 +61,8 @@ Use any [Symfony Cache](http://symfony.com/doc/current/components/cache.html) co
 
 ```php
 use BotMan\BotMan\Cache\SymfonyCache;
-use Symfony\Component\Cache\Simple\FilesystemCache;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
-$adapter = new FilesystemCache();
+$adapter = new FilesystemAdapter();
 $botman = BotManFactory::create($config, new SymfonyCache($adapter));
 ```


### PR DESCRIPTION
This PR fixes a reference to the wrong class in the Symfony Filesystem Cache documentation.  `SymfonyCache` accepts an instance of `Symfony\Component\Cache\Adapter\FilesystemAdapter`, which is implemented by `FilesystemAdapter` rather than `FilesystemCache`.