### PR TITLE
Add note to "Retrieve The Username"

### DIFF
--- a/user-information.md
+++ b/user-information.md
@@ -60,6 +60,7 @@ $user = $bot->getUser();
 // Access Username
 $id = $user->getUsername();
 ```
+Be aware that you might not receive any username data if the user hasn't set a username in their messenger settings.
 
 <a id="retrieving-raw-user-information"></a>
 ### Retrieve The Raw User Information


### PR DESCRIPTION
Noticed I did not receive any username from telegram until I went to `settings` and set my username. This might not be of interest for some, but as I actually saved the username in my db, I got an error because of this. So it might be worth mentioning