### PR TITLE
Add Laravel Cache section

### DIFF
--- a/cache-drivers.md
+++ b/cache-drivers.md
@@ -24,6 +24,16 @@ $adapter = new MyCustomPsr6CacheAdapter();
 $botman = BotManFactory::create($config, new Psr6Cache($adapter));
 ```
 
+<a id="laravel"></a>
+### Laravel Cache
+When using botman in an existing Laravel project, you can use the Botman's built in LaravelCache.
+
+```php
+use BotMan\BotMan\Cache\LaravelCache;
+
+$botman = BotManFactory::create($config, new LaravelCache());
+```
+
 <a id="doctrine"></a>
 ### Doctrine Cache
 Use any [Doctrine Cache](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/caching.html) driver by passing it to the factory:

--- a/cache-drivers.md
+++ b/cache-drivers.md
@@ -1,6 +1,7 @@
 # Cache drivers
 
 - [PSR6 Cache](#psr6)
+- [Laravel Cache](#laravel)
 - [Doctrine Cache](#doctrine)
 - [CodeIgniter Cache](#codeigniter)
 - [Redis Cache](#redis)


### PR DESCRIPTION
When not using Botman studio, but using Botman in an existing Laravel project, and one wants to use a cache driver, it was not represented in the documentation that people can use Botman's built in LaravelCache().
Actually ran into this issue for one of my own projects.
Source of the solution: https://medium.com/@carre_sam/how-to-implement-botman-into-your-existing-laravel-project-without-studio-df92cff98e94